### PR TITLE
환율 정보를 최신화 하기 위해 첫 호출 이후 매 시간마다 CurrencyLayerDto를 업데이트 해주는 스케줄러 작성

### DIFF
--- a/src/main/java/com/example/currencyexchange/CurrencyexchangeApplication.java
+++ b/src/main/java/com/example/currencyexchange/CurrencyexchangeApplication.java
@@ -2,8 +2,10 @@ package com.example.currencyexchange;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CurrencyexchangeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/currencyexchange/controller/CurrencyLayerRESTController.java
+++ b/src/main/java/com/example/currencyexchange/controller/CurrencyLayerRESTController.java
@@ -27,6 +27,11 @@ public class CurrencyLayerRESTController {
         return new ResponseEntity(currencyLayerDto, HttpStatus.OK);
     }
 
+//    @GetMapping("/receiving-amount")
+//    public ResponseEntity getReceivingAmount(@Valid @ModelAttribute InputDto inputDto) {
+//       return null;
+//    }
+
 //    @GetMapping("/exchangerate")
 //    public Mono<ResponseEntity<CurrencyLayerDto>> getExchangeRate(){
 ////        Mono<CurrencyLayerDto> searchResult = currencyLayerAPIService.getCurrencyRate();

--- a/src/main/java/com/example/currencyexchange/scheduler/UpdateCurrencyRate.java
+++ b/src/main/java/com/example/currencyexchange/scheduler/UpdateCurrencyRate.java
@@ -1,4 +1,22 @@
 package com.example.currencyexchange.scheduler;
 
+import com.example.currencyexchange.service.CurrencyLayerAPIService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
 public class UpdateCurrencyRate {
+
+    @Autowired
+    CurrencyLayerAPIService currencyLayerAPIService;
+
+    @Scheduled(fixedDelay = 3600000)
+    public void updateCurrencyRates() {
+        currencyLayerAPIService.getCurrencyRate();
+        log.info("updated currency rates");
+    }
 }

--- a/src/main/java/com/example/currencyexchange/service/CurrencyLayerAPIServiceImpl.java
+++ b/src/main/java/com/example/currencyexchange/service/CurrencyLayerAPIServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.currencyexchange.dto.CurrencyLayerDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -28,22 +29,19 @@ public class CurrencyLayerAPIServiceImpl implements CurrencyLayerAPIService {
 
     @Override
     public CurrencyLayerDto getCurrencyRate() {
-        currencyLayerDtoMono = webClient.get().uri("/live?access_key=" + accessKey+ "&source=" + source + "&currencies=" + currencies)
-                .retrieve()
-                .bodyToMono(CurrencyLayerDto.class);
-        currencyLayerDto = currencyLayerDtoMono.block();
-        System.out.println(currencyLayerDto.getQuotes());
-        System.out.println(currencyLayerDto.getTimestamp());
-        System.out.println(currencyLayerDto.getError());
-        return currencyLayerDto;
+            currencyLayerDtoMono = webClient.get().uri("/live?access_key=" + accessKey + "&source=" + source + "&currencies=" + currencies)
+                    .retrieve()
+                    .bodyToMono(CurrencyLayerDto.class);
+            currencyLayerDto = currencyLayerDtoMono.block();
+
+            if(currencyLayerDto == null){
+                throw new RestClientException("환율정보를 불러오지 못했습니다.");
+            }else if(!currencyLayerDto.isSuccess()){
+                throw new RestClientException("API 호출간 에러가 발생했습니다."
+                        + currencyLayerDto.getError().get("code") + " : "
+                        + currencyLayerDto.getError().get("type"));
+            }
+            return currencyLayerDto;
     }
 
-
-//    @Override
-//    public Mono<CurrencyLayerDto> getCurrencyRate() {
-//        Mono<CurrencyLayerDto> currencyLayerDtoMono = webClient.get().uri("/live?access_key=" + accessKey+ "&source=" + source + "&currencies=" + currencies)
-//                .retrieve()
-//                .bodyToMono(CurrencyLayerDto.class);
-//        return currencyLayerDtoMono;
-//    }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -37,8 +37,8 @@
                 환율:
             </p>
             <p>
-                <label for="input">송금액:</label>
-                <input type="text" id="input" style="width: 240px;" placeholder="송금할 금액을 입력하세요."> <b>USD</b></input>
+                <label for="amount">송금액:</label>
+                <input type="text" id="amount" style="width: 240px;" placeholder="송금할 금액을 입력하세요."> <b>USD</b></input>
             </p>
             <p>
                 <button class="btn btn-dark" onclick="calculateCurrency()">Submit</button>
@@ -54,6 +54,7 @@
     function calculateCurrency(){
         var from = $('#from').val();
         var to = $('#to').val();
+        var amount = $('#amount').val();
         $.ajax({
             url: "/api/exchangerate",
             type: 'get',

--- a/src/test/java/com/example/currencyexchange/service/CurrencyLayerAPIServiceTest.java
+++ b/src/test/java/com/example/currencyexchange/service/CurrencyLayerAPIServiceTest.java
@@ -22,12 +22,9 @@ public class CurrencyLayerAPIServiceTest {
 
     @Test
     public void 환율정보_불러오기(){
-//        Mono<CurrencyLayerDto> searchResult = currencyLayerAPIService.getCurrencyRate();
-//        Assert.assertNotNull(searchResult);
-//        searchResult.doOnNext(r->{
-//            System.out.println("result: " + r.getQuotes());
-//        } ).subscribe();
-////        LOGGER.info("test result: {}", searchResult.block());
+        CurrencyLayerDto searchResult = currencyLayerAPIService.getCurrencyRate();
+        Assert.assertNotNull(searchResult);
+
     }
 
 }

--- a/target/classes/templates/index.html
+++ b/target/classes/templates/index.html
@@ -37,8 +37,8 @@
                 환율:
             </p>
             <p>
-                <label for="input">송금액:</label>
-                <input type="text" id="input" style="width: 240px;" placeholder="송금할 금액을 입력하세요."> <b>USD</b></input>
+                <label for="amount">송금액:</label>
+                <input type="text" id="amount" style="width: 240px;" placeholder="송금할 금액을 입력하세요."> <b>USD</b></input>
             </p>
             <p>
                 <button class="btn btn-dark" onclick="calculateCurrency()">Submit</button>
@@ -54,6 +54,7 @@
     function calculateCurrency(){
         var from = $('#from').val();
         var to = $('#to').val();
+        var amount = $('#amount').val();
         $.ajax({
             url: "/api/exchangerate",
             type: 'get',


### PR DESCRIPTION
스케줄러를 사용해서 최신화를 해주고 있는데
생각보다 효율적이지 못한 것 같음.

처음 페이지가 로딩이 되었을 때 환율정보를 가지고 와야 하는데 update에만 의존하면 페이지가 로딩이 될 때마다 메서드 호출이 되어서 api 호출이 너무 남발 되는 것 같음

조금 더 생각해보고 수정을 하거나 다른 메서드를 추가하거나 해야할 듯 싶다.