### PR TITLE
JPN으로 되어있는 오타를 JPY로 변경

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -29,7 +29,7 @@
                 <label for="to">수취 국가: </label>
                 <select id="to">
                     <option selected value="KRW">한국(KRW)</option>
-                    <option value="JPN">일본(JPN)</option>
+                    <option value="JPY">일본(JPN)</option>
                     <option value="PHP">필리핀(PHP)</option>
                 </select>
             </p>
@@ -54,7 +54,7 @@
     $(document).ready(function(){
         getCurrencyRate();
     });
-    select.addEventListener('change',function(){
+    $('select').on('change', function() {
         getCurrencyRate();
     });
 


### PR DESCRIPTION
javascript의 addEventListener가 작동을 안해서
select에서 change가 일어날 경우 eventlistener를 jQuery로 변경
